### PR TITLE
Use a var for github base url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for nrser.nodenv
 nodenv_update: false
+nodenv_github_base_url: https://github.com/nodenv

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: install nodenv (OiNutter version)
   git:
-    repo: https://github.com/OiNutter/nodenv
+    repo: "{{ nodenv_github_base_url }}/nodenv"
     dest: ~/.nodenv
     update: "{{ nodenv_update }}"
 
@@ -19,7 +19,7 @@
 
 - name: install node-build
   git:
-    repo: https://github.com/OiNutter/node-build.git
+    repo: "{{ nodenv_github_base_url }}/node-build.git"
     dest: ~/.nodenv/plugins/node-build
     update: "{{ nodenv_update }}"
 
@@ -39,7 +39,7 @@
 
 - name: install node-build
   git:
-    repo: https://github.com/OiNutter/node-build.git
+    repo: "{{ nodenv_github_base_url }}/node-build.git"
     dest: ~/.nodenv/plugins/node-build
     update: true
   when: nodenv_build_needs_update


### PR DESCRIPTION
And set the default to "https://github.com/nodenv"

The nodenv repos have moved to the "nodenv" org.

This makes the base URL configurable to support that move.
